### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/nicovt/4e5ee35d-0a1d-4627-aad3-24ceeafbc4b6/caca062f-3d3a-41c9-aa1c-eded6d9c5c49/_apis/work/boardbadge/eef7a2f2-d573-4e06-a536-10bb4cce6570)](https://dev.azure.com/nicovt/4e5ee35d-0a1d-4627-aad3-24ceeafbc4b6/_boards/board/t/caca062f-3d3a-41c9-aa1c-eded6d9c5c49/Microsoft.RequirementCategory)
 Calculator.js: a node.js Demonstration Project
 ==============================================
 An example node.js project, including tests with mocha, that behaves like


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#14](https://dev.azure.com/nicovt/4e5ee35d-0a1d-4627-aad3-24ceeafbc4b6/_workitems/edit/14). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.